### PR TITLE
Fix `trusted_domains` check

### DIFF
--- a/set_configuration.sh
+++ b/set_configuration.sh
@@ -4,7 +4,7 @@ set -x
 
 docker exec -u www-data app-server php occ --no-warnings config:system:get trusted_domains >> trusted_domain.tmp
 
-if ! grep -q "app-server" trusted_domain.tmp; then
+if ! grep -q "nginx-server" trusted_domain.tmp; then
     TRUSTED_INDEX=$(cat trusted_domain.tmp | wc -l);
     docker exec -u www-data app-server php occ --no-warnings config:system:set trusted_domains $TRUSTED_INDEX --value="nginx-server"
 fi


### PR DESCRIPTION
From what I can tell, the purpose of this bit of code is to check if `nginx-server` is already a trusted domain, and append it to the list if it is not. However this is not working correctly because `app-server` is checked for instead, so duplicate entries of `nginx-server` are created if the script is run more than once.

It's entirely possible that I don't understand what's going on here, and the code is actually correct as-is, in which case this PR should of course be closed. If this is so, could you provide a brief explanation of what this code is doing?